### PR TITLE
UInt is actually a thing in Perl 6

### DIFF
--- a/lib/Factorial.pm6
+++ b/lib/Factorial.pm6
@@ -5,7 +5,7 @@ use v6.c;
 unit module Factorial;
 
 #factorial 
-sub postfix:<!>(Int $operand where $operand >= 0)
+sub postfix:<!>(UInt $operand)
 		is tighter(&infix:<**>)
 	   	is export {
 	[*] 1..$operand;


### PR DESCRIPTION
So use that instead of a custom `where`